### PR TITLE
setting lower retention for uploaded artifacts

### DIFF
--- a/.github/workflows/hugo--build-release-deploy.yml
+++ b/.github/workflows/hugo--build-release-deploy.yml
@@ -159,7 +159,7 @@ jobs:
         with:
           path: "./${{ inputs.build-artifact-name }}.tar.gz"
           name: "${{ inputs.build-artifact-name }}"
-          retention-days: 9
+          retention-days: 2
 
 ###################
 ###   RELEASE   ###

--- a/.github/workflows/hugo--build-release.yml
+++ b/.github/workflows/hugo--build-release.yml
@@ -162,7 +162,7 @@ jobs:
         with:
           path: "./${{ inputs.build-artifact-name }}.tar.gz"
           name: "${{ inputs.build-artifact-name }}"
-          retention-days: 9
+          retention-days: 2
 
 ###################
 ###   RELEASE   ###


### PR DESCRIPTION
no need to keep uploaded artifacts longer after successful deployment