### PR TITLE
replacing actions/create-release and actions/upload-release-asset wit…

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -221,27 +221,15 @@ jobs:
           echo '```' >> RELEASE.md
 
       - id: create_release
-        name: Create semvar release
-        uses: actions/create-release@v1.1.4
+        name: Create semvar release and upload tarball
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          owner: "${{ inputs.github-repository-owner }}"
-          repo: "${{ inputs.github-repository-name }}"
-          release_name: ${{ env.RELEASE_NAME }}
           tag_name: ${{ env.RELEASE_TAG_NAME }}
-          body_path: "./RELEASE.md" 
-    
-      - id: upload-release-asset
-        name: Upload Release Tarball Asset
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: "./${{ inputs.release-artifact-tarball-filename }}"
-          asset_name: "${{ inputs.release-artifact-tarball-filename }}"
-          asset_content_type: application/tar+gzip
+          name: ${{ env.RELEASE_NAME }}
+          body_path: ./RELEASE.md
+          files: "./${{ inputs.release-artifact-tarball-filename }}"
     outputs:
       release_name: ${{ env.RELEASE_NAME }}
 

--- a/.github/workflows/hugo--build-release-deploy.yml
+++ b/.github/workflows/hugo--build-release-deploy.yml
@@ -229,27 +229,15 @@ jobs:
           echo '```' >> RELEASE.md
 
       - id: create_release
-        name: Create release
-        uses: actions/create-release@v1.1.4
+        name: Create release and upload tarball
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          owner: "${{ github.repository_owner }}"
-          repo: "${{ github.repository_name }}"
-          release_name: ${{ env.RELEASE_NAME }}
           tag_name: ${{ env.RELEASE_TAG_NAME }}
-          body_path: "./RELEASE.md"
-
-      - id: upload-release-asset
-        name: Upload Release Tarball Asset
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: "./${{ inputs.build-artifact-name }}.tar.gz"
-          asset_name: "${{ inputs.build-artifact-name }}.tar.gz"
-          asset_content_type: application/tar+gzip
+          name: ${{ env.RELEASE_NAME }}
+          body_path: ./RELEASE.md
+          files: "./${{ inputs.build-artifact-name }}.tar.gz"
 
     outputs:
       release_name: ${{ env.RELEASE_NAME }}

--- a/.github/workflows/jekyll--build-release-deploy.yml
+++ b/.github/workflows/jekyll--build-release-deploy.yml
@@ -279,27 +279,15 @@ jobs:
           echo '```' >> RELEASE.md
 
       - id: create_release
-        name: Create semvar release
-        uses: actions/create-release@v1.1.4
+        name: Create semvar release and upload tarball
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          owner: "${{ github.repository_owner }}"
-          repo: "${{ github.repository_name }}"
-          release_name: ${{ env.RELEASE_NAME }}
           tag_name: ${{ env.RELEASE_TAG_NAME }}
-          body_path: "./RELEASE.md" 
-    
-      - id: upload-release-asset
-        name: Upload Release Tarball Asset
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: "./${{ inputs.build-artifact-name }}.tar.gz"
-          asset_name: "${{ inputs.build-artifact-name }}.tar.gz"
-          asset_content_type: application/tar+gzip
+          name: ${{ env.RELEASE_NAME }}
+          body_path: ./RELEASE.md
+          files: "./${{ inputs.build-artifact-name }}.tar.gz"
     outputs:
       release_name: ${{ env.RELEASE_NAME }}
 


### PR DESCRIPTION
…h softprops/action-gh-release@v2 in remaining release workflows

applies the same migration as 19a51e8 to create-release.yml, hugo--build-release-deploy.yml, and jekyll--build-release-deploy.yml. owner/repo inputs dropped since softprops/action-gh-release infers them from GITHUB_REPOSITORY, which resolves to the caller's repo for reusable workflows (matching prior behavior).