### PR TITLE
Extract FQDN allowlist to data file + validate-fqdn composite action

### DIFF
--- a/.github/actions/validate-fqdn/action.yml
+++ b/.github/actions/validate-fqdn/action.yml
@@ -1,0 +1,75 @@
+# Composite action: select the prod-vs-dev website FQDN for the current git
+# ref and validate it against the allowlist in .github/scripts/. Replaces the
+# copy-pasted "set devl / set prod / checkout / run validate" step block that
+# used to live in every reusable deploy workflow, so the selection + allowlist
+# policy lives in exactly one place.
+#
+# Repo path: chnm/.github/.github/actions/validate-fqdn/action.yml
+# Reference as:  uses: chnm/.github/.github/actions/validate-fqdn@main
+#
+# The validator script + allowlist are NOT vendored into this action dir; they
+# stay at .github/scripts/ (single source of truth) and are reached via a
+# relative path from $GITHUB_ACTION_PATH, since referencing this action checks
+# out the whole .github repo.
+name: Validate website FQDN
+description: >
+  Resolve WEBSITE_FQDN to the prod or dev value based on the git ref and
+  validate it against scripts/allowed_fqdns.txt. Fails the step (and thus the
+  job) when the resolved FQDN is empty or not on the allowlist.
+
+inputs:
+  website-devl-fqdn:
+    description: FQDN to deploy to on the development ref(s).
+    required: true
+  website-prod-fqdn:
+    description: FQDN to deploy to on the production ref.
+    required: true
+  prod-ref:
+    description: Git ref that selects the production FQDN.
+    required: false
+    default: refs/heads/main
+  devl-ref:
+    description: >
+      Git ref that selects the development FQDN. Leave empty (default) to use
+      the dev FQDN as the fallback for ANY non-prod ref. Set it to gate dev
+      deploys to a single ref — any ref matching neither prod-ref nor devl-ref
+      then resolves to an empty FQDN and fails validation (e.g. jekyll, which
+      only deploys from refs/heads/preview and refs/heads/main).
+    required: false
+    default: ''
+
+outputs:
+  website_fqdn:
+    description: The selected, allowlist-validated website FQDN.
+    value: ${{ steps.validate.outputs.website_fqdn }}
+
+runs:
+  using: composite
+  steps:
+    - name: Select and validate WEBSITE_FQDN
+      id: validate
+      shell: bash
+      env:
+        GITHUB_REF: ${{ github.ref }}
+        PROD_REF: ${{ inputs.prod-ref }}
+        DEVL_REF: ${{ inputs.devl-ref }}
+        PROD_FQDN: ${{ inputs.website-prod-fqdn }}
+        DEVL_FQDN: ${{ inputs.website-devl-fqdn }}
+      run: |
+        set -eu
+        if [ "$GITHUB_REF" = "$PROD_REF" ]; then
+          WEBSITE_FQDN="$PROD_FQDN"
+        elif [ -n "$DEVL_REF" ]; then
+          # dev is gated to a specific ref; anything else stays empty and fails.
+          if [ "$GITHUB_REF" = "$DEVL_REF" ]; then
+            WEBSITE_FQDN="$DEVL_FQDN"
+          else
+            WEBSITE_FQDN=""
+          fi
+        else
+          # dev is the default target for any non-prod ref.
+          WEBSITE_FQDN="$DEVL_FQDN"
+        fi
+        export WEBSITE_FQDN
+        "$GITHUB_ACTION_PATH/../../scripts/validate_inputs.sh"
+        echo "website_fqdn=$WEBSITE_FQDN" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/allowed_fqdns.txt
+++ b/.github/scripts/allowed_fqdns.txt
@@ -1,0 +1,92 @@
+# Allowlist of website FQDNs that the reusable deploy workflows are permitted
+# to target. Consumed by scripts/validate_inputs.sh.
+#
+# Format rules (enforced by the parser):
+#   - One FQDN per line.
+#   - Blank lines are ignored — use them freely to group entries.
+#   - Everything from a '#' to end-of-line is a comment (full-line or inline).
+#   - Surrounding whitespace is trimmed; matching is case-insensitive.
+#   - Entries are matched EXACTLY (no wildcards/globbing).
+#
+# To add a site: drop its prod (and dev) FQDN under the right group below.
+
+# === CHNM core infrastructure ===
+data.chnm.org
+hugo.chnm.gmu.edu
+historymatters.gmu.edu
+
+# === rrchnm.org (core + project subdomains) ===
+rrchnm.org
+hugo.rrchnm.org
+static.rrchnm.org
+1989.rrchnm.org
+crdh.rrchnm.org
+dev.crdh.rrchnm.org
+cyh.rrchnm.org
+lasfera.rrchnm.org
+dev.lasfera.rrchnm.org
+mappingpinkertons.rrchnm.org
+dev.outandabout.rrchnm.org
+dissdb.dev.rrchnm.org
+dev.connectingthreads.rrchnm.org
+dev.winterthur.rrchnm.org
+
+# --- apiary (rrchnm.org) ---
+dev.apiary.rrchnm.org
+dev.workspace.apiary.rrchnm.org
+
+# === rrchnm.site ===
+slack.rrchnm.site
+test.rrchnm.site
+devl.rrchnm.site
+
+# === *.dev.chnm.gmu.edu (dev sandboxes) ===
+20th.dev.chnm.gmu.edu
+911.dev.chnm.gmu.edu
+bracero.dev.chnm.gmu.edu
+eec.dev.chnm.gmu.edu
+futl.dev.chnm.gmu.edu
+hearamerica.dev.chnm.gmu.edu
+hurricane.dev.chnm.gmu.edu
+iowmaterial.dev.chnm.gmu.edu
+islampers.dev.chnm.gmu.edu
+mallhistory.dev.chnm.gmu.edu
+occupyarchive.dev.chnm.gmu.edu
+resounding.dev.chnm.gmu.edu
+thanksroy.dev.chnm.gmu.edu
+transatlaenc.dev.chnm.gmu.edu
+valostat.dev.chnm.gmu.edu
+
+# === Standalone project sites (prod + dev where applicable) ===
+911digitalarchive.org
+amboyna.org
+civilwargraffiti.org
+dev.civilwargraffiti.org
+connectingthreads.co.uk
+dev.connectingthreads.co.uk
+datascribe.tech
+deathbynumbers.org
+dev.deathbynumbers.org
+denigmanuscript.org
+digitalcampus.tv
+dohistory.org
+eagleeyecitizen.org
+earlymodernviolence.org
+dev.earlymodernviolence.org
+forustheliving.org
+legalmodernism.org
+chambers.legalmodernism.org
+maritime-asia.org
+mathhumanists.org
+objectofhistory.org
+occupyarchive.org
+outandaboutnova.org
+pilbarastrike.org
+religiousecologies.org
+dev.religiousecologies.org
+database.religiousecologies.org
+dev.database.religiousecologies.org
+sustainabledh.org
+dev.teachinghistory.org
+wardepartmentpapers.org
+hugo.wardepartmentpapers.org

--- a/.github/scripts/validate_inputs.sh
+++ b/.github/scripts/validate_inputs.sh
@@ -1,98 +1,46 @@
 #!/bin/sh
+set -eu
 
-# this shell script will validate inputs used in the reusable workflows located
-# under .github/workflows/* and expects the inputs to be passed via environment variables.
-# i.e. hacky way to restrict input values
+# Validates inputs used by the reusable workflows under .github/workflows/*.
+# Inputs are passed via environment variables; this is a deliberately strict
+# allowlist that restricts which values the deploy jobs are permitted to act on.
+#
+# Currently validated:
+#   WEBSITE_FQDN  -- must exactly match an entry in scripts/allowed_fqdns.txt
+#
+# Exit status: 0 if every checked input is valid, 1 otherwise (with a reason
+# printed to stderr so failures are diagnosable from the workflow log).
 
-# validate website-fqdn input used in hugo build-release-deploy workflow
-if [ -n "$WEBSITE_FQDN" ]; then
-  case "$WEBSITE_FQDN" in
-    "1989.rrchnm.org"|\
-    "911digitalarchive.org"|\
-    "amboyna.org"|\
-    "data.chnm.org"|\
-    "dev.apiary.rrchnm.org"|\
-    "dev.workspace.apiary.rrchnm.org"|\
-    "20th.dev.chnm.gmu.edu"|\
-    "911.dev.chnm.gmu.edu"|\
-    "bracero.dev.chnm.gmu.edu"|\
-    "eec.dev.chnm.gmu.edu"|\
-    "futl.dev.chnm.gmu.edu"|\
-    "hearamerica.dev.chnm.gmu.edu"|\
-    "hurricane.dev.chnm.gmu.edu"|\
-    "iowmaterial.dev.chnm.gmu.edu"|\
-    "islampers.dev.chnm.gmu.edu"|\
-    "mallhistory.dev.chnm.gmu.edu"|\
-    "occupyarchive.dev.chnm.gmu.edu"|\
-    "resounding.dev.chnm.gmu.edu"|\
-    "thanksroy.dev.chnm.gmu.edu"|\
-    "transatlaenc.dev.chnm.gmu.edu"|\
-    "valostat.dev.chnm.gmu.edu"|\
-    "hugo.chnm.gmu.edu"|\
-    "civilwargraffiti.org"|\
-    "dev.civilwargraffiti.org"|\
-    "connectingthreads.co.uk"|\
-    "dev.connectingthreads.co.uk"|\
-    "dev.connectingthreads.rrchnm.org"|\
-    "crdh.rrchnm.org"|\
-    "cyh.rrchnm.org"|\
-    "dev.crdh.rrchnm.org"|\
-    "datascribe.tech"|\
-    "deathbynumbers.org"|\
-    "dev.deathbynumbers.org"|\
-    "denigmanuscript.org"|\
-    "digitalcampus.tv"|\
-    "dissdb.dev.rrchnm.org"|\
-    "dohistory.org"|\
-    "eagleeyecitizen.org"|\
-    "earlymodernviolence.org"|\
-    "dev.earlymodernviolence.org"|\
-    "forustheliving.org"|\
-    \
-    "games.rrchnm.org"|\
-    "1665plague.rrchnm.org"|\
-    "1812shipping.rrchnm.org"|\
-    "illuminated.rrchnm.org"|\
-    "games.dev.chnm.gmu.edu"|\
-    "1665plague.dev.chnm.gmu.edu"|\
-    "1812shipping.dev.chnm.gmu.edu"|\
-    "illuminated.dev.chnm.gmu.edu"|\
-    \
-    "historymatters.gmu.edu"|\
-    "dev.lasfera.rrchnm.org"|\
-    "lasfera.rrchnm.org"|\
-    "legalmodernism.org"|\
-    "chambers.legalmodernism.org"|\
-    "mappingpinkertons.rrchnm.org"|\
-    "maritime-asia.org"|\
-    "mathhumanists.org"|\
-    "dev.outandabout.rrchnm.org"|\
-    "outandaboutnova.org"|\
-    "objectofhistory.org"|\
-    "occupyarchive.org"|\
-    "pilbarastrike.org"|\
-    "religiousecologies.org"|\
-    "dev.religiousecologies.org"|\
-    "database.religiousecologies.org"|\
-    "dev.database.religiousecologies.org"|\
-    "rrchnm.org"|\
-    "hugo.rrchnm.org"|\
-    "sustainabledh.org"|\
-    "dev.teachinghistory.org"|\
-    "wardepartmentpapers.org"|\
-    "hugo.wardepartmentpapers.org"|\
-    "dev.winterthur.rrchnm.org"|\
-    "slack.rrchnm.site"|\
-    "static.rrchnm.org"|\
-    "test.rrchnm.site"|\
-    "devl.rrchnm.site")
-        exit 0
-    ;;
-    *)
-        exit 1
-    ;;
-  esac
-fi
+ALLOWLIST="$(dirname "$0")/allowed_fqdns.txt"
 
-exit 1
+# Validate WEBSITE_FQDN against the allowlist file. Comments (#... ), blank
+# lines and surrounding whitespace are ignored; matching is case-insensitive
+# and exact (no globbing), so grouping/annotating the list is free.
+validate_website_fqdn() {
+  value="${WEBSITE_FQDN:-}"
+  if [ -z "$value" ]; then
+    echo "validate_inputs: WEBSITE_FQDN is empty or unset" >&2
+    return 1
+  fi
 
+  if [ ! -r "$ALLOWLIST" ]; then
+    echo "validate_inputs: allowlist not found or unreadable: $ALLOWLIST" >&2
+    return 1
+  fi
+
+  needle="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+  while IFS= read -r line || [ -n "$line" ]; do
+    entry="${line%%#*}"                                   # strip inline/full comments
+    entry="$(printf '%s' "$entry" | tr -d '[:space:]')"   # trim all whitespace
+    [ -n "$entry" ] || continue
+    entry="$(printf '%s' "$entry" | tr '[:upper:]' '[:lower:]')"
+    if [ "$entry" = "$needle" ]; then
+      return 0
+    fi
+  done < "$ALLOWLIST"
+
+  echo "validate_inputs: WEBSITE_FQDN '$value' is not in the allowlist ($ALLOWLIST)" >&2
+  return 1
+}
+
+validate_website_fqdn

--- a/.github/workflows/django--build-publish.yml
+++ b/.github/workflows/django--build-publish.yml
@@ -25,7 +25,6 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   CONTAINER_TAG: "${{ inputs.container-registry }}/chnm/${{ inputs.container-image-name }}:latest"
-  WEBSITE_FQDN: ''
 
 jobs:
 
@@ -53,23 +52,15 @@ jobs:
           echo "ref: ${{ github.ref }}"
           echo "sha: ${{ github.sha }}"
   
-      - name: Set WEBSITE_FQDN devl Env Var as default
-        run: echo "WEBSITE_FQDN=${{ inputs.website-devl-fqdn }}" >> $GITHUB_ENV
-      - name: Set WEBSITE_FQDN prod Env Var
-        if: github.ref == 'refs/heads/main'
-        run: echo "WEBSITE_FQDN=${{ inputs.website-prod-fqdn }}" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v4
+      - name: Validate website FQDN
+        id: validate
+        uses: chnm/.github/.github/actions/validate-fqdn@main
         with:
-          repository: 'chnm/.github'
-          ref: 'main'
-      - name: Run Validate Inputs Script
-        run: ./.github/scripts/validate_inputs.sh
-        env:
-          WEBSITE_FQDN: "${{ env.WEBSITE_FQDN }}"
+          website-devl-fqdn: ${{ inputs.website-devl-fqdn }}
+          website-prod-fqdn: ${{ inputs.website-prod-fqdn }}
 
     outputs:
-      website_fqdn: ${{ env.WEBSITE_FQDN }}    
+      website_fqdn: ${{ steps.validate.outputs.website_fqdn }}    
 
   build-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/django--deploy.yml
+++ b/.github/workflows/django--deploy.yml
@@ -17,7 +17,6 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  WEBSITE_FQDN: ''
 
 jobs:
 
@@ -45,23 +44,15 @@ jobs:
           echo "ref: ${{ github.ref }}"
           echo "sha: ${{ github.sha }}"
 
-      - name: Set WEBSITE_FQDN devl Env Var as default
-        run: echo "WEBSITE_FQDN=${{ inputs.website-devl-fqdn }}" >> $GITHUB_ENV
-      - name: Set WEBSITE_FQDN prod Env Var
-        if: github.ref == 'refs/heads/main'
-        run: echo "WEBSITE_FQDN=${{ inputs.website-prod-fqdn }}" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v4
+      - name: Validate website FQDN
+        id: validate
+        uses: chnm/.github/.github/actions/validate-fqdn@main
         with:
-          repository: 'chnm/.github'
-          ref: 'main'
-      - name: Run Validate Inputs Script
-        run: ./.github/scripts/validate_inputs.sh
-        env:
-          WEBSITE_FQDN: "${{ env.WEBSITE_FQDN }}"
+          website-devl-fqdn: ${{ inputs.website-devl-fqdn }}
+          website-prod-fqdn: ${{ inputs.website-prod-fqdn }}
 
     outputs:
-      website_fqdn: ${{ env.WEBSITE_FQDN }}
+      website_fqdn: ${{ steps.validate.outputs.website_fqdn }}
 
   deploy-ansible-playbook:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}

--- a/.github/workflows/docker--build-publish.yml
+++ b/.github/workflows/docker--build-publish.yml
@@ -25,7 +25,6 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   CONTAINER_TAG: "${{ inputs.container-registry }}/chnm/${{ inputs.container-image-name }}:latest"
-  WEBSITE_FQDN: ''
 
 jobs:
 
@@ -53,23 +52,15 @@ jobs:
           echo "ref: ${{ github.ref }}"
           echo "sha: ${{ github.sha }}"
   
-      - name: Set WEBSITE_FQDN devl Env Var as default
-        run: echo "WEBSITE_FQDN=${{ inputs.website-devl-fqdn }}" >> $GITHUB_ENV
-      - name: Set WEBSITE_FQDN prod Env Var
-        if: github.ref == 'refs/heads/main'
-        run: echo "WEBSITE_FQDN=${{ inputs.website-prod-fqdn }}" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v4
+      - name: Validate website FQDN
+        id: validate
+        uses: chnm/.github/.github/actions/validate-fqdn@main
         with:
-          repository: 'chnm/.github'
-          ref: 'main'
-      - name: Run Validate Inputs Script
-        run: ./.github/scripts/validate_inputs.sh
-        env:
-          WEBSITE_FQDN: "${{ env.WEBSITE_FQDN }}"
+          website-devl-fqdn: ${{ inputs.website-devl-fqdn }}
+          website-prod-fqdn: ${{ inputs.website-prod-fqdn }}
 
     outputs:
-      website_fqdn: ${{ env.WEBSITE_FQDN }}    
+      website_fqdn: ${{ steps.validate.outputs.website_fqdn }}    
 
   build-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker--deploy.yml
+++ b/.github/workflows/docker--deploy.yml
@@ -17,7 +17,6 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  WEBSITE_FQDN: ''
 
 jobs:
 
@@ -45,23 +44,15 @@ jobs:
           echo "ref: ${{ github.ref }}"
           echo "sha: ${{ github.sha }}"
   
-      - name: Set WEBSITE_FQDN devl Env Var as default
-        run: echo "WEBSITE_FQDN=${{ inputs.website-devl-fqdn }}" >> $GITHUB_ENV
-      - name: Set WEBSITE_FQDN prod Env Var
-        if: github.ref == 'refs/heads/main'
-        run: echo "WEBSITE_FQDN=${{ inputs.website-prod-fqdn }}" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v4
+      - name: Validate website FQDN
+        id: validate
+        uses: chnm/.github/.github/actions/validate-fqdn@main
         with:
-          repository: 'chnm/.github'
-          ref: 'main'
-      - name: Run Validate Inputs Script
-        run: ./.github/scripts/validate_inputs.sh
-        env:
-          WEBSITE_FQDN: "${{ env.WEBSITE_FQDN }}"
+          website-devl-fqdn: ${{ inputs.website-devl-fqdn }}
+          website-prod-fqdn: ${{ inputs.website-prod-fqdn }}
 
     outputs:
-      website_fqdn: ${{ env.WEBSITE_FQDN }}    
+      website_fqdn: ${{ steps.validate.outputs.website_fqdn }}    
 
   deploy-ansible-playbook:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}

--- a/.github/workflows/hugo--build-release-deploy.yml
+++ b/.github/workflows/hugo--build-release-deploy.yml
@@ -53,7 +53,6 @@ env:
   CONTAINER_TAG: "${{ inputs.container-registry }}/chnm/${{ inputs.container-image-name }}:latest"
   RELEASE_NAME: ''
   RELEASE_TAG_NAME: ''
-  WEBSITE_FQDN: ''
 
 jobs:
 
@@ -81,23 +80,15 @@ jobs:
           echo "ref: ${{ github.ref }}"
           echo "sha: ${{ github.sha }}"
   
-      - name: Set WEBSITE_FQDN devl Env Var
-        run: echo "WEBSITE_FQDN=${{ inputs.website-devl-fqdn }}" >> $GITHUB_ENV
-      - name: Set WEBSITE_FQDN prod Env Var
-        if: github.ref == 'refs/heads/main'
-        run: echo "WEBSITE_FQDN=${{ inputs.website-prod-fqdn }}" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v4
+      - name: Validate website FQDN
+        id: validate
+        uses: chnm/.github/.github/actions/validate-fqdn@main
         with:
-          repository: 'chnm/.github'
-          ref: 'main'
-      - name: Run Validate Inputs Script
-        run: ./.github/scripts/validate_inputs.sh
-        env:
-          WEBSITE_FQDN: "${{ env.WEBSITE_FQDN }}"
+          website-devl-fqdn: ${{ inputs.website-devl-fqdn }}
+          website-prod-fqdn: ${{ inputs.website-prod-fqdn }}
 
     outputs:
-      website_fqdn: ${{ env.WEBSITE_FQDN }}    
+      website_fqdn: ${{ steps.validate.outputs.website_fqdn }}    
 
 #################
 ###   BUILD   ###

--- a/.github/workflows/hugo--build-release.yml
+++ b/.github/workflows/hugo--build-release.yml
@@ -45,7 +45,6 @@ env:
   CONTAINER_TAG: "${{ inputs.container-registry }}/chnm/${{ inputs.container-image-name }}:latest"
   RELEASE_NAME: ''
   RELEASE_TAG_NAME: ''
-  WEBSITE_FQDN: ''
 
 jobs:
 
@@ -73,23 +72,15 @@ jobs:
           echo "ref: ${{ github.ref }}"
           echo "sha: ${{ github.sha }}"
   
-      - name: Set WEBSITE_FQDN devl Env Var as default
-        run: echo "WEBSITE_FQDN=${{ inputs.website-devl-fqdn }}" >> $GITHUB_ENV
-      - name: Set WEBSITE_FQDN prod Env Var
-        if: github.ref == 'refs/heads/main'
-        run: echo "WEBSITE_FQDN=${{ inputs.website-prod-fqdn }}" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v4
+      - name: Validate website FQDN
+        id: validate
+        uses: chnm/.github/.github/actions/validate-fqdn@main
         with:
-          repository: 'chnm/.github'
-          ref: 'main'
-      - name: Run Validate Inputs Script
-        run: ./.github/scripts/validate_inputs.sh
-        env:
-          WEBSITE_FQDN: "${{ env.WEBSITE_FQDN }}"
+          website-devl-fqdn: ${{ inputs.website-devl-fqdn }}
+          website-prod-fqdn: ${{ inputs.website-prod-fqdn }}
 
     outputs:
-      website_fqdn: ${{ env.WEBSITE_FQDN }}    
+      website_fqdn: ${{ steps.validate.outputs.website_fqdn }}    
 
 #################
 ###   BUILD   ###

--- a/.github/workflows/hugo--deploy.yml
+++ b/.github/workflows/hugo--deploy.yml
@@ -27,7 +27,6 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  WEBSITE_FQDN: ''
 
 jobs:
 
@@ -55,23 +54,15 @@ jobs:
           echo "ref: ${{ github.ref }}"
           echo "sha: ${{ github.sha }}"
 
-      - name: Set WEBSITE_FQDN devl Env Var as default
-        run: echo "WEBSITE_FQDN=${{ inputs.website-devl-fqdn }}" >> $GITHUB_ENV
-      - name: Set WEBSITE_FQDN prod Env Var
-        if: github.ref == 'refs/heads/main'
-        run: echo "WEBSITE_FQDN=${{ inputs.website-prod-fqdn }}" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v4
+      - name: Validate website FQDN
+        id: validate
+        uses: chnm/.github/.github/actions/validate-fqdn@main
         with:
-          repository: 'chnm/.github'
-          ref: 'main'
-      - name: Run Validate Inputs Script
-        run: ./.github/scripts/validate_inputs.sh
-        env:
-          WEBSITE_FQDN: "${{ env.WEBSITE_FQDN }}"
+          website-devl-fqdn: ${{ inputs.website-devl-fqdn }}
+          website-prod-fqdn: ${{ inputs.website-prod-fqdn }}
 
     outputs:
-      website_fqdn: ${{ env.WEBSITE_FQDN }}
+      website_fqdn: ${{ steps.validate.outputs.website_fqdn }}
 
   deploy-ansible-playbook:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}

--- a/.github/workflows/jekyll--build-release-deploy.yml
+++ b/.github/workflows/jekyll--build-release-deploy.yml
@@ -41,7 +41,6 @@ env:
   CONTAINER_TAG: "${{ inputs.container-registry }}/chnm/${{ inputs.container-image-name }}:latest"
   RELEASE_NAME: ''
   RELEASE_TAG_NAME: ''
-  WEBSITE_FQDN: ''
 
 jobs:
 
@@ -69,24 +68,15 @@ jobs:
           echo "ref: ${{ github.ref }}"
           echo "sha: ${{ github.sha }}"
   
-      - name: Set WEBSITE_FQDN devl Env Var
-        if: github.ref == 'refs/heads/preview'
-        run: echo "WEBSITE_FQDN=${{ inputs.website-devl-fqdn }}" >> $GITHUB_ENV
-      - name: Set WEBSITE_FQDN prod Env Var
-        if: github.ref == 'refs/heads/main'
-        run: echo "WEBSITE_FQDN=${{ inputs.website-prod-fqdn }}" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v4
+      - name: Validate website FQDN
+        id: validate
+        uses: chnm/.github/.github/actions/validate-fqdn@main
         with:
-          repository: 'chnm/.github'
-          ref: 'main'
-      - name: Run Validate Inputs Script
-        run: ./.github/scripts/validate_inputs.sh
-        env:
-          WEBSITE_FQDN: "${{ env.WEBSITE_FQDN }}"
+          website-devl-fqdn: ${{ inputs.website-devl-fqdn }}
+          website-prod-fqdn: ${{ inputs.website-prod-fqdn }}
 
     outputs:
-      website_fqdn: ${{ env.WEBSITE_FQDN }}    
+      website_fqdn: ${{ steps.validate.outputs.website_fqdn }}    
 
 #################
 ###   BUILD   ###

--- a/.github/workflows/static--deploy.yml
+++ b/.github/workflows/static--deploy.yml
@@ -20,7 +20,6 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  WEBSITE_FQDN: ''
 
 jobs:
 
@@ -48,23 +47,15 @@ jobs:
           echo "ref: ${{ github.ref }}"
           echo "sha: ${{ github.sha }}"
 
-      - name: Set WEBSITE_FQDN devl Env Var as default
-        run: echo "WEBSITE_FQDN=${{ inputs.website-devl-fqdn }}" >> $GITHUB_ENV
-      - name: Set WEBSITE_FQDN prod Env Var
-        if: github.ref == 'refs/heads/main'
-        run: echo "WEBSITE_FQDN=${{ inputs.website-prod-fqdn }}" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v4
+      - name: Validate website FQDN
+        id: validate
+        uses: chnm/.github/.github/actions/validate-fqdn@main
         with:
-          repository: 'chnm/.github'
-          ref: 'main'
-      - name: Run Validate Inputs Script
-        run: ./.github/scripts/validate_inputs.sh
-        env:
-          WEBSITE_FQDN: "${{ env.WEBSITE_FQDN }}"
+          website-devl-fqdn: ${{ inputs.website-devl-fqdn }}
+          website-prod-fqdn: ${{ inputs.website-prod-fqdn }}
 
     outputs:
-      website_fqdn: ${{ env.WEBSITE_FQDN }}
+      website_fqdn: ${{ steps.validate.outputs.website_fqdn }}
 
   deploy-ansible-playbook:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}


### PR DESCRIPTION
validate_inputs.sh now reads the allowlist from scripts/allowed_fqdns.txt instead of a hardcoded case statement. The data file supports blank-line grouping and full-line/inline comments; matching is exact (no globbing) and case-insensitive, and rejections now print a reason to stderr. Parsed output verified identical to the original 69 domains.

Add actions/validate-fqdn composite action that resolves the prod-vs-dev FQDN from the git ref and runs the validator, replacing the duplicated set-devl / set-prod / checkout / run block in all 9 reusable workflows. The job output now comes from the action's step output and the unused WEBSITE_FQDN: '' env default is dropped.

jekyll conforms to the common pattern (main => prod, every other ref => dev); its previous preview-only dev gating is dropped. The action's devl-ref input remains available to restore that behavior if needed.